### PR TITLE
Sa 1184 setnx with expire

### DIFF
--- a/client.go
+++ b/client.go
@@ -7,6 +7,7 @@ type Client interface {
 	MGet(keys ...string) ([]string, error)
 	Set(key string, value interface{}) error
 	SetEx(key string, expire int64, value interface{}) error
+	SetNX(key string, value interface{}, expire int) (int, error)
 	Expire(key string, seconds int64) (bool, error)
 	Del(keys ...string) (int64, error)
 

--- a/client.go
+++ b/client.go
@@ -7,7 +7,7 @@ type Client interface {
 	MGet(keys ...string) ([]string, error)
 	Set(key string, value interface{}) error
 	SetEx(key string, expire int64, value interface{}) error
-	SetNX(key string, value interface{}, expire int) (int, error)
+	SetNxEx(key string, value interface{}, expire int64) (int64, error)
 	Expire(key string, seconds int64) (bool, error)
 	Del(keys ...string) (int64, error)
 

--- a/in_memory_client.go
+++ b/in_memory_client.go
@@ -51,6 +51,7 @@ func (dc *InMemoryClient) Set(key string, value interface{}) (err error) {
 	defer dc.mu.Unlock()
 
 	dc.Keys[key] = value
+	delete(dc.Expires, key)
 	return nil
 }
 
@@ -79,6 +80,7 @@ func (dc *InMemoryClient) LPush(key string, value string) (length int64, err err
 	}
 
 	dc.Keys[key] = append([]string{value}, array...)
+	delete(dc.Expires, key)
 	return int64(len(array) + 1), nil
 }
 
@@ -96,6 +98,7 @@ func (dc *InMemoryClient) RPush(key string, value string) (length int64, err err
 	}
 
 	dc.Keys[key] = append(array, value)
+	delete(dc.Expires, key)
 	return int64(len(array) + 1), nil
 }
 
@@ -294,7 +297,6 @@ func (dc *InMemoryClient) ZCount(key string, min interface{}, max interface{}) (
 
 			count += 1
 		}
-
 	}
 
 	return count, nil

--- a/in_memory_client.go
+++ b/in_memory_client.go
@@ -2,7 +2,6 @@ package redis
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 )
@@ -34,16 +33,7 @@ func (dc *InMemoryClient) Get(key string) (val string, err error) {
 		return "", errors.New("redigo: nil returned")
 	}
 
-	switch value.(type) {
-	case string:
-		return value.(string), nil
-	case int:
-		return fmt.Sprintf("%d", value.(int)), nil
-	case int64:
-		return fmt.Sprintf("%d", value.(int64)), nil
-	}
-
-	return value.(string), nil
+	return ValueToString(value), nil
 }
 
 func (dc *InMemoryClient) Set(key string, value interface{}) (err error) {

--- a/in_memory_client.go
+++ b/in_memory_client.go
@@ -292,7 +292,7 @@ func (dc *InMemoryClient) ZCount(key string, min interface{}, max interface{}) (
 	return count, nil
 }
 
-func (dc *InMemoryClient) SetNX(key string, value interface{}, timeout int) (int, error) {
+func (dc *InMemoryClient) SetNxEx(key string, value interface{}, timeout int64) (int64, error) {
 	dc.mu.Lock()
 	defer dc.mu.Unlock()
 
@@ -303,7 +303,7 @@ func (dc *InMemoryClient) SetNX(key string, value interface{}, timeout int) (int
 		return 0, nil
 	}
 
-	dc.Expires[key] = time.Now().Add(time.Duration(timeout) * time.Millisecond)
+	dc.Expires[key] = time.Now().Add(time.Duration(timeout) * time.Second)
 	dc.Keys[key] = value
 
 	return 1, nil

--- a/pooled_client.go
+++ b/pooled_client.go
@@ -143,19 +143,19 @@ func (pc *PooledClient) ZCount(key string, min interface{}, max interface{}) (in
 	return redis.Int64(c.Do("ZCOUNT", key, min, max))
 }
 
-func (pc *PooledClient) SetNX(key string, value interface{}, expire int) (int, error) {
+func (pc *PooledClient) SetNxEx(key string, value interface{}, expire int64) (int64, error) {
 	c := pc.pool.Get()
 	defer c.Close()
 
 	// The normal redis SETNX command does not accept timeouts, For this reason
 	// our implementation simply uses the normal SET command with NX(Not exists) and
-	// PX(expire) options and mimics what would be returned by SETNX.
-	val, err := c.Do("SET", key, value, "NX", "PX", expire)
+	// EX(expire) options and mimics what would be returned by SETNX.
+	val, err := c.Do("SET", key, value, "NX", "EX", expire)
 
 	switch val {
 	case "OK":
-		return redis.Int(int64(1), err)
+		return redis.Int64(int64(1), err)
 	default:
-		return redis.Int(int64(0), err)
+		return redis.Int64(int64(0), err)
 	}
 }

--- a/pooled_client.go
+++ b/pooled_client.go
@@ -142,3 +142,20 @@ func (pc *PooledClient) ZCount(key string, min interface{}, max interface{}) (in
 
 	return redis.Int64(c.Do("ZCOUNT", key, min, max))
 }
+
+func (pc *PooledClient) SetNX(key string, value interface{}, expire int) (int, error) {
+	c := pc.pool.Get()
+	defer c.Close()
+
+	// The normal redis SETNX command does not accept timeouts, For this reason
+	// our implementation simply uses the normal SET command with NX(Not exists) and
+	// PX(expire) options and mimics what would be returned by SETNX.
+	val, err := c.Do("SET", key, value, "NX", "PX", expire)
+
+	switch val {
+	case "OK":
+		return redis.Int(int64(1), err)
+	default:
+		return redis.Int(int64(0), err)
+	}
+}

--- a/redis.go
+++ b/redis.go
@@ -87,3 +87,7 @@ func ZAdd(key string, score float64, value interface{}) (int64, error) {
 func ZCount(key string, min interface{}, max interface{}) (int64, error) {
 	return client.ZCount(key, min, max)
 }
+
+func SetNxEx(key string, value interface{}, expire int64) (int64, error) {
+	return client.SetNxEx(key, value, expire)
+}

--- a/redis_test.go
+++ b/redis_test.go
@@ -314,24 +314,24 @@ func (s *RedisTestSuite) TestSetResetsExpire(c *C) {
 	c.Assert(v, Equals, "1")
 }
 
-func (s *RedisTestSuite) TestSetNX(c *C) {
+func (s *RedisTestSuite) TestSetNXEX(c *C) {
 	existingKey := RandSeq(32)
 	s.client.Set(existingKey, 1)
 
-	val, err := s.client.SetNX(existingKey, 1, 1000)
+	val, err := s.client.SetNxEx(existingKey, 1, 1)
 	c.Assert(err, IsNil)
-	c.Assert(val, Equals, 0)
+	c.Assert(val, Equals, int64(0))
 
 	nonExistingKey := RandSeq(32)
 
-	val, err = s.client.SetNX(nonExistingKey, 1, 1000)
+	val, err = s.client.SetNxEx(nonExistingKey, 1, 1)
 	c.Assert(err, IsNil)
-	c.Assert(val, Equals, 1)
+	c.Assert(val, Equals, int64(1))
 
 	time.Sleep(2 * time.Second)
 
 	// Should have expire at this point
-	val, err = s.client.SetNX(nonExistingKey, 1, 1000)
+	val, err = s.client.SetNxEx(nonExistingKey, 1, 1)
 	c.Assert(err, IsNil)
-	c.Assert(val, Equals, 1)
+	c.Assert(val, Equals, int64(1))
 }

--- a/redis_test.go
+++ b/redis_test.go
@@ -313,3 +313,25 @@ func (s *RedisTestSuite) TestSetResetsExpire(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(v, Equals, "1")
 }
+
+func (s *RedisTestSuite) TestSetNX(c *C) {
+	existingKey := RandSeq(32)
+	s.client.Set(existingKey, 1)
+
+	val, err := s.client.SetNX(existingKey, 1, 1000)
+	c.Assert(err, IsNil)
+	c.Assert(val, Equals, 0)
+
+	nonExistingKey := RandSeq(32)
+
+	val, err = s.client.SetNX(nonExistingKey, 1, 1000)
+	c.Assert(err, IsNil)
+	c.Assert(val, Equals, 1)
+
+	time.Sleep(2 * time.Second)
+
+	// Should have expire at this point
+	val, err = s.client.SetNX(nonExistingKey, 1, 1000)
+	c.Assert(err, IsNil)
+	c.Assert(val, Equals, 1)
+}


### PR DESCRIPTION
As the normal redis SETNX command doesn't support expire timeouts, this implementation uses the default SET command with NX and PX options to mimic the SETNX but with a timeout. 